### PR TITLE
Added keyboard shortcut to show/hide the graph pane

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import joplin from 'api';
 import * as joplinData from './data';
 import { registerSettings } from './settings';
-import { ToolbarButtonLocation } from 'api/types';
+import { MenuItemLocation, ToolbarButtonLocation } from 'api/types';
 var deepEqual = require('deep-equal')
 
 /**
@@ -127,7 +127,7 @@ joplin.plugins.register({
       },
     });
     await joplin.views.toolbarButtons.create('graphUIButton', 'showHideGraphUI', ToolbarButtonLocation.NoteToolbar);
-
+    await joplin.views.menuItems.create('showOrHideGraphMenuItem','showHideGraphUI',MenuItemLocation.View,{accelerator:"F8"});
     // Build Panel
     await panels.addScript(view, './d3.min.js');
     await panels.addScript(view, './webview.css');


### PR DESCRIPTION
Added a Menu Item to Show or Hide the Graph Pane.

1. Menu Item is added under View Menu
2. Added F8 as the shortcut for it.

PFB the image of the menu item.

![image](https://user-images.githubusercontent.com/17808008/134856164-91edad60-4df0-45af-83f6-be67548ddb0e.png)



Closes issue #30 