### PR TITLE
Fix broken graph edges when note links to anchor (#42)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,14 @@ async function fetchData() {
 
   notes.forEach(function(note, id) {
     var links = note["links"]
-    for (const link of links) {
+    for (let link of links) {
+
+      // Slice note link if link directs to an anchor  
+      var index = link.indexOf("#");
+      if(index != -1){
+        link = link.substr(0,index);
+      }
+
       var linkDestExists = notes.has(link);
       if (linkDestExists) {
         data.edges.push({


### PR DESCRIPTION
Partial Fix for #42

Simple temporary fix (not that fluent in JS) for the missing graph edges, when a note links to another note´s anchor (e.g. Headings).
Forthcoming, the graph could be extended so that it not only links to the note, but also to its anchors.

