### PR TITLE
Add Hover link and node feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-plugin-link-graph-ui",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "scripts": {
     "dist": "webpack --joplin-plugin-config buildMain && webpack --joplin-plugin-config buildExtraScripts && webpack --joplin-plugin-config createArchive",
     "dev": "webpack --mode development --joplin-plugin-config buildMain && webpack --joplin-plugin-config buildExtraScripts && webpack --joplin-plugin-config createArchive",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 1,
 	"id": "io.treymo.LinkGraph",
 	"app_min_version": "1.7",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"name": "Link Graph UI",
 	"description": "Visualize the connections between Joplin notes.",
 	"author": "Trey Mo",

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -119,7 +119,7 @@ function buildGraph(data) {
     // marker, if whole graph is shown
     addMarkerEndDef(defs, "default");
     // on hover marker
-    _addMarkerEndDef(defs, "hovered-link", "var(--joplin-color-error2");
+    _addMarkerEndDef(defs, "hovered-link", "var(--hover-secondary-color");
   }
 
   //add zoom capabilities

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -59,11 +59,14 @@ function buildGraph(data) {
   width = window.innerWidth;
   height = window.innerHeight;
 
-  if (data.graphIsSelectionBased) {
+  if (data.graphIsSelectionBased)
     document
       .querySelector("#note_graph")
       .classList.add("mode-selection-based-graph");
-  }
+  else
+    document
+      .querySelector("#note_graph")
+      .classList.remove("mode-selection-based-graph");
 
   d3.select("#note_graph > svg").remove();
   svg = d3

--- a/src/webview.css
+++ b/src/webview.css
@@ -29,8 +29,6 @@ button {
 }
 
 circle {
-  fill: var(--distance-remaining-primary-color);
-  stroke: var(--distance-remaining-secondary-color);
   r: 10;
 }
 
@@ -41,21 +39,11 @@ circle {
 
 .current-note {
   fill: var(--distance-0-primary-color);
-  stroke: var(--distance-0-secondary-color);
   r: 18;
 }
 
 line {
   stroke: var(--distance-remaining-primary-color);
-}
-
-line.distance-0 {
-  stroke: var(--distance-0-primary-color);
-  stroke-width: 3px;
-}
-
-line.distance-1 {
-  stroke: var(--distance-1-primary-color);
 }
 
 .adjacent-line {
@@ -91,16 +79,77 @@ line.distance-1 {
 }
 
 /*
- * Make nodes far away from selected nodes less apparent:
- * Remove stroke for circles > distance-2 in selection-based graphs
+ * WHOLE GRAPH MODE [START]
  */
-#note_graph.mode-selection-based-graph circle:not(.distance-0):not(.distance-1):not(.distance-2) {
-  stroke: unset;
+
+:not(#note_graph.mode-selection-based-graph) circle:not(.current-note):not(.adjacent-note) {
+  stroke: var(--distance-remaining-secondary-color);
+  stroke-width: 2;
+  fill: var(--distance-remaining-primary-color);
 }
 
 /*
- * Mark links which are directed inwards/towards selected note
+ * WHOLE GRAPH MODE [END]
  */
+
+/*
+ * DISTANCE-BASED GRAPH MODE [START]
+ */
+
+#note_graph {
+    /* distance colors for selection-based graph */
+    --distance-0-primary-color: var(--joplin-color);
+    --distance-0-secondary-color: var(--joplin-color4);
+    --distance-1-primary-color: var(--joplin-color4);
+    --distance-1-secondary-color: var(--joplin-color);
+    --distance-remaining-primary-color: var(--joplin-background-color-hover3);
+    --distance-remaining-secondary-color: var(--joplin-color4);
+    --distance-remaining-label-color: var(--joplin-color-faded);
+}
+
+#note_graph.mode-selection-based-graph line.distance-0 {
+  stroke: var(--distance-0-primary-color);
+  stroke-width: 3px;
+}
+
+#note_graph.mode-selection-based-graph line.distance-1 {
+  stroke: var(--distance-1-primary-color);
+}
+
+#note_graph.mode-selection-based-graph circle.distance-2 {
+  stroke: var(--distance-remaining-secondary-color);
+  stroke-width: 2;
+}
+
+#note_graph.mode-selection-based-graph circle:not(.distance-0):not(.distance-1):not(.distance-2) {
+  /*
+   * Make nodes far away from selected nodes less apparent:
+   * Remove stroke for circles > distance-2 in selection-based graphs
+   */
+  stroke: unset;
+  fill: var(--distance-remaining-primary-color);
+}
+
 #note_graph.mode-selection-based-graph .inward-link {
+  /* Mark links which are directed inwards/towards selected note */
   stroke-dasharray: 3;
 }
+
+#note_graph.mode-selection-based-graph text.node-label.distance-0 {
+  font-size: 150%;
+  font-weight: bold;
+}
+
+#note_graph.mode-selection-based-graph text.node-label.distance-1 {
+  font-size: 125%;
+  fill: var(--distance-1-primary-color);
+}
+
+#note_graph.mode-selection-based-graph text.node-label:not(.distance-0):not(.distance-1):not(.distance-2) {
+  font-size: 80%;
+  fill: var(--distance-remaining-label-color);
+}
+
+/*
+ * DISTANCE-BASED GRAPH MODE [END]
+ */

--- a/src/webview.css
+++ b/src/webview.css
@@ -56,16 +56,16 @@ line {
 }
 
 .hovered-node {
-  fill: var(--joplin-color-error) !important;
+  fill: var(--hover-primary-color) !important;
   stroke: unset !important;
 }
 
 .hovered-node-label {
-  fill: var(--joplin-color-error2) !important;
+  fill: var(--hover-secondary-color) !important;
 }
 
 .hovered-link {
-  stroke: var(--joplin-color-error2) !important;
+  stroke: var(--hover-secondary-color) !important;
 }
 
 #note_graph {
@@ -76,6 +76,9 @@ line {
   --distance-1-secondary-color: var(--joplin-color);
   --distance-remaining-primary-color: var(--joplin-background-color-hover3);
   --distance-remaining-secondary-color: var(--joplin-color4);
+
+  --hover-primary-color: #93f500;
+  --hover-secondary-color: var(--joplin-color-correct);
 }
 
 /*

--- a/src/webview.css
+++ b/src/webview.css
@@ -67,6 +67,19 @@ line.distance-1 {
   fill: var(--joplin-color);
 }
 
+.hovered-node {
+  fill: var(--joplin-color-error) !important;
+  stroke: unset !important;
+}
+
+.hovered-node-label {
+  fill: var(--joplin-color-error2) !important;
+}
+
+.hovered-link {
+  stroke: var(--joplin-color-error2) !important;
+}
+
 #note_graph {
   /* distance colors for selection-based graph */
   --distance-0-primary-color: var(--joplin-color);


### PR DESCRIPTION
Feat: On link hover, highlight source and target note incl. labels #58 
Feat: On note hover, for all links highlight source and target note incl. labels

Minor Fix: Properly toggle graph mode (https://github.com/treymo/joplin-link-graph/compare/main...goliath-walker:feat-hover?expand=1#diff-0ab86666b99a06c57c509a8b80148b035d7273ea88847a2776138529f3435d6fL57-R69)
Minor Feat: Optimized default style for distance-based graph mode
Refactor: Distinguish more clearly between graph mode styles in CSS file
