### PR TITLE
Feat: List tags as tooltip on node hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-plugin-link-graph-ui",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "scripts": {
     "dist": "webpack --joplin-plugin-config buildMain && webpack --joplin-plugin-config buildExtraScripts && webpack --joplin-plugin-config createArchive",
     "dev": "webpack --mode development --joplin-plugin-config buildMain && webpack --joplin-plugin-config buildExtraScripts && webpack --joplin-plugin-config createArchive",

--- a/src/data.ts
+++ b/src/data.ts
@@ -253,3 +253,22 @@ async function getAllBacklinksForNote(noteId: string) {
   } while (response.has_more);
   return links;
 }
+
+type Tag = {
+  id: string;
+  title: string;
+};
+
+export async function getNoteTags(noteId: string) {
+  const tags: Tag[] = [];
+  let pageNum = 1;
+  let response;
+  do {
+    response = await joplin.data.get(["notes", noteId, "tags"], {
+      fields: ["id", "title"],
+      page: pageNum++,
+    });
+    tags.push(...response.items);
+  } while (response.has_more);
+  return tags;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,16 +89,20 @@ joplin.plugins.register({
     await panels.addScript(view, "./ui/index.js");
 
     panels.onMessage(view, async (message: any) => {
-      if (message.name === "poll") {
-        let p = new Promise((resolve) => {
-          pollCb = resolve;
-        });
-        notifyUI();
-        return p;
-      } else if (message.name === "update") {
-        return { name: "update", data: data };
-      } else if (message.name === "navigateTo") {
-        joplin.commands.execute("openNote", message.id);
+      switch (message.name) {
+        case "poll":
+          let p = new Promise((resolve) => {
+            pollCb = resolve;
+          });
+          notifyUI();
+          return p;
+        case "update":
+          return { name: "update", data: data };
+        case "navigateTo":
+          joplin.commands.execute("openNote", message.id);
+          break;
+        case "get_note_tags":
+          return await joplinData.getNoteTags(message.id);
       }
     });
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 1,
 	"id": "io.treymo.LinkGraph",
 	"app_min_version": "1.7",
-	"version": "1.4.0",
+	"version": "1.5.0",
 	"name": "Link Graph UI",
 	"description": "Visualize the connections between Joplin notes.",
 	"author": "Trey Mo",

--- a/src/webview.css
+++ b/src/webview.css
@@ -32,6 +32,27 @@ circle {
   r: 10;
 }
 
+.tooltip {
+  position: absolute;
+  /*transform: translateX(-50%); */
+  margin-top: 10px;
+  display: flex;
+  column-gap: 5px;
+  row-gap: 3px;
+  flex-wrap: wrap;
+  flex-direction: row;
+}
+
+.tooltip.hidden {
+  display: none;
+}
+
+.tooltip .node-hover-tag {
+   background-color: var(--joplin-background-color-hover3); 
+   border-radius: 100px;
+   padding: 5px;
+}
+
 .adjacent-note {
   fill: var(--distance-1-primary-color);
   r: 13;
@@ -55,17 +76,21 @@ line {
   fill: var(--joplin-color);
 }
 
-.hovered-node {
+line.adjacent-to-hovered {
+  stroke: var(--hover-secondary-color) !important;
+}
+
+circle.adjacent-to-hovered {
   fill: var(--hover-primary-color) !important;
   stroke: unset !important;
 }
 
-.hovered-node-label {
-  fill: var(--hover-secondary-color) !important;
+circle.hovered {
+  filter: brightness(50%);
 }
 
-.hovered-link {
-  stroke: var(--hover-secondary-color) !important;
+text.adjacent-to-hovered {
+  fill: var(--hover-secondary-color) !important;
 }
 
 #note_graph {


### PR DESCRIPTION
Hovering a node in the graph will now show a list of all note tags at the bottom for better overview and graph traversal