### PR TITLE
Feat: Add inline graph setting for max distance (maxDegree)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,7 @@ interface GraphData {
   nodeFontSize: number;
   nodeDistanceRatio: number;
   showLinkDirection: boolean;
-  // maxDegree > 0
-  graphIsSelectionBased: boolean;
+  graphIsSelectionBased: boolean; // maxDegree > 0
 }
 
 let data: GraphData;
@@ -54,6 +53,7 @@ joplin.plugins.register({
                         <p class="header">Note Graph</p>
                       </div>
                       <div class="container">
+                        <div id="user-input-container"></div>
                         <div id="note_graph"/>
                       </div>
         </div>
@@ -88,7 +88,7 @@ joplin.plugins.register({
     await panels.addScript(view, "./webview.css");
     await panels.addScript(view, "./ui/index.js");
 
-    panels.onMessage(view, async (message: any) => {
+    panels.onMessage(view, (message: any) => {
       switch (message.name) {
         case "poll":
           let p = new Promise((resolve) => {
@@ -102,7 +102,11 @@ joplin.plugins.register({
           joplin.commands.execute("openNote", message.id);
           break;
         case "get_note_tags":
-          return await joplinData.getNoteTags(message.id);
+          return joplinData.getNoteTags(message.id);
+        case "set_setting":
+          return joplin.settings.setValue(message.key, message.value);
+        case "get_setting":
+          return joplin.settings.value(message.key);
       }
     });
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -77,7 +77,7 @@ export async function registerSettings() {
       type: SettingItemType.Int,
       minimum: 0,
       section: sectionName,
-      public: true,
+      public: false,
       label: "Max degree of separation",
       description:
         "Maximum number of link jumps from selected note. Zero for all notes",

--- a/src/ui/user-input.js
+++ b/src/ui/user-input.js
@@ -1,0 +1,45 @@
+const container = document.getElementById("user-input-container");
+
+function chromeRangeInputFix() {
+  // workaround for chrome concerning range inputs,
+  // not allowing slider to be dragged.
+  // See https://stackoverflow.com/q/69490604
+  // todo: is there a better solution?
+  document.querySelectorAll('input[type="range"]').forEach((input) => {
+    input.addEventListener("mousedown", () =>
+      window.getSelection().removeAllRanges()
+    );
+  });
+}
+
+function initDistanceRangeInput(initialValue, handleChange) {
+  const html = `
+  <label for="maxDistance">Max. distance</label>
+  <input 
+    name="maxDistance"
+    type="range"
+    min="0"
+    value="${initialValue}"
+    max="5"
+    step="1"
+  >
+  <output>${initialValue}</output>
+  `;
+  container.insertAdjacentHTML("beforeend", html);
+  const input = container.querySelector("input[name='maxDistance']")
+  input.addEventListener("input", function () {
+    const output = this.nextElementSibling;
+    output.value = this.value;
+  });
+  input.addEventListener("change", function () {
+    handleChange(this.valueAsNumber);
+  });
+}
+
+export function init(initDistanceValue, handleDistanceChange, handleRedraw) {
+  chromeRangeInputFix();
+  initDistanceRangeInput(initDistanceValue, handleDistanceChange);
+  document
+    .getElementById("redrawButton")
+    .addEventListener("click", handleRedraw);
+}

--- a/src/webview.css
+++ b/src/webview.css
@@ -3,6 +3,24 @@
   background-color: var(--joplin-background-color) !important;
 }
 
+.graph-content > .container {
+  /* anchor the inline settings container */
+  position:relative;
+} 
+
+#user-input-container {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  display: flex;
+  align-items: center;
+  column-gap: 5px;
+}
+
+#user-input-container label, #user-input-container output {
+  user-select: none;
+}
+
 .header-area {
   width: 100%
 }

--- a/src/webview.css
+++ b/src/webview.css
@@ -182,17 +182,21 @@ text.adjacent-to-hovered {
 }
 
 #note_graph.mode-selection-based-graph text.node-label.distance-0 {
-  font-size: 150%;
+  font-size: 20px;
   font-weight: bold;
 }
 
 #note_graph.mode-selection-based-graph text.node-label.distance-1 {
-  font-size: 125%;
+  font-size: 18px;
   fill: var(--distance-1-primary-color);
 }
 
+#note_graph.mode-selection-based-graph text.node-label.distance-2 {
+  font-size: 16px;
+}
+
 #note_graph.mode-selection-based-graph text.node-label:not(.distance-0):not(.distance-1):not(.distance-2) {
-  font-size: 80%;
+  font-size: 14px;
   fill: var(--distance-remaining-label-color);
 }
 


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/99182604/163421838-00d786ee-a204-47b0-bf49-d31ba98bfc59.png)

Inline settings allow quick adjustments to viewed graph and its distance.
`maxDegree` setting is removed from the settings (made private),  but still is persisted each time the  range slider is changed.

Second commit is a quick-fix for degrading font-size, when distance gets bigger. Previous percent-based settings did not make so much sense, as no proper parent element to rely on.