### PR TITLE
Handle no note being selected

### DIFF
--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -9,7 +9,7 @@ import { getFilterFunction } from "./filter";
 /**
  * Collects notes from Joplin according to given parameters
  *
- * @param selectedNote ID of currently selected note, used when getting linked notes
+ * @param selectedNote ID of currently selected note, null when there is none, used when getting linked notes
  * @param maxNotes maximum notes to collect, used when getting all notes
  * @param maxDegree maximum distance away from the current note to get notes for, used when getting linked notes, set to 0 to get all notes
  * @param filteredNotebookNames comma separated string of notebooks to ***exclude***, values should be names
@@ -18,7 +18,7 @@ import { getFilterFunction } from "./filter";
  * @param includeBacklinks boolean toggle to also use backlinks to collect notes, used when getting linked notes
  */
 async function getNotes(
-    selectedNote: string,
+    selectedNote: string | null,
     maxNotes: number,
     maxDegree: number,
     filteredNotebookNames: string,

--- a/src/data/graph.test.ts
+++ b/src/data/graph.test.ts
@@ -72,3 +72,22 @@ describe("buildGraphData", () => {
     });
   });
 });
+
+describe("buildGraphData with no note selected", () => {
+  it("still draws every note", () => {
+    const data = buildGraphData(noteMap(note("a", ["b"]), note("b")), null, display);
+    expect(data.nodes.map((n) => n.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("still draws the links between them", () => {
+    const data = buildGraphData(noteMap(note("a", ["b"]), note("b")), null, display);
+    expect(edgeIds(data)).toEqual(["a->b"]);
+  });
+
+  it("focuses nothing", () => {
+    const notes = noteMap(note("a", ["b"]), note("b"));
+    const data = buildGraphData(notes, null, display);
+    expect(data.edges.some((e) => e.focused)).toBe(false);
+    expect(data.nodes.some((n) => n.focused)).toBe(false);
+  });
+});

--- a/src/data/graph.ts
+++ b/src/data/graph.ts
@@ -18,7 +18,7 @@ export interface Node {
 export interface GraphData {
   nodes: Node[];
   edges: Edge[];
-  currentNoteID: string;
+  currentNoteID: string | null;
   nodeFontSize: number;
   nodeDistanceRatio: number;
   showLinkDirection: boolean;
@@ -39,12 +39,12 @@ export interface DisplaySettings {
  * Flattens the collected notes into the node and edge lists the webview draws.
  *
  * @param notes notes to draw, keyed by id
- * @param selectedNoteId note Joplin has selected
+ * @param selectedNoteId note Joplin has selected, null when there is none
  * @param display drawing settings passed through to the webview
  */
 export function buildGraphData(
   notes: Map<string, Note>,
-  selectedNoteId: string,
+  selectedNoteId: string | null,
   display: DisplaySettings
 ): GraphData {
   const data: GraphData = {

--- a/src/data/notes.test.ts
+++ b/src/data/notes.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
-import { getAllLinksForNote } from "./notes";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getAllLinksForNote, getLinkedNotes } from "./notes";
+import { Note } from "./types";
+import joplin from "api";
 
 describe("getAllLinksForNote", () => {
   it("finds the target id of a markdown link", () => {
@@ -45,5 +47,23 @@ describe("getAllLinksForNote", () => {
 
   it("cannot tell a resource link from a note link", () => {
     expect(getAllLinksForNote("![shot](:/res456)")).toEqual(new Set(["res456"]));
+  });
+});
+
+describe("getLinkedNotes with no note selected", () => {
+  const keepAll = (nm: Map<string, Note>) => nm;
+
+  beforeEach(() => {
+    vi.mocked(joplin.data.get).mockReset();
+  });
+
+  it("collects no notes", async () => {
+    const notes = await getLinkedNotes(null, 1, false, keepAll);
+    expect(notes.size).toBe(0);
+  });
+
+  it("asks Joplin for nothing", async () => {
+    await getLinkedNotes(null, 1, false, keepAll);
+    expect(joplin.data.get).not.toHaveBeenCalled();
   });
 });

--- a/src/data/notes.ts
+++ b/src/data/notes.ts
@@ -41,13 +41,13 @@ export async function getAllNotes(
 /**
  * Fetch all notes linked to a given source note, up to a maximum degree of separation
  *
- * @param source_id ID of currently selected note
+ * @param source_id ID of currently selected note, null when there is none
  * @param maxDegree maximum distance away from the current note to get notes for
  * @param includeBacklinks boolean toggle to also use backlinks to collect notes
  * @param filterFunc filter function to exclude notes according to values used when it was created
  */
 export async function getLinkedNotes(
-  source_id: string,
+  source_id: string | null,
   maxDegree: number,
   includeBacklinks: boolean,
   filterFunc: (nm: Map<string, Note>) => Map<string, Note>
@@ -56,6 +56,12 @@ export async function getLinkedNotes(
   let visited = new Set();
   let noteMap = new Map();
   let degree = 0;
+
+  // A traversal outward from the selected note has nowhere to start when
+  // Joplin has no note selected.
+  if (source_id === null) {
+    return noteMap;
+  }
 
   pending.push(source_id);
   do {

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,9 @@ joplin.plugins.register({
       } else {
         if (eventName === "noteChange") {
           const selectedNote = await joplin.workspace.selectedNote();
-          var noteLinks = getAllLinksForNote(selectedNote.body);
+          var noteLinks = getAllLinksForNote(
+            selectedNote ? selectedNote.body : ""
+          );
           if (linksChanged(prevNoteLinks, noteLinks)) {
             prevNoteLinks = noteLinks;
             dataChanged = true;
@@ -111,15 +113,18 @@ joplin.plugins.register({
         } else if (eventName === "noteSelectionChange" && maxDegree == 0) {
           // noteSelectionChange should just re-center the graph, no need to fetch all new data and compare.
           const newlySelectedNote = await joplin.workspace.selectedNote();
-          data.currentNoteID = newlySelectedNote.id;
+          const newlySelectedNoteId = newlySelectedNote
+            ? newlySelectedNote.id
+            : null;
+          data.currentNoteID = newlySelectedNoteId;
           data.edges.forEach((edge) => {
             const shouldHaveFocus =
-              edge.source === newlySelectedNote.id ||
-              edge.target === newlySelectedNote.id;
+              edge.source === newlySelectedNoteId ||
+              edge.target === newlySelectedNoteId;
             edge.focused = shouldHaveFocus;
           });
           data.nodes.forEach((node) => {
-            node.focused = node.id === newlySelectedNote.id;
+            node.focused = node.id === newlySelectedNoteId;
           });
           dataChanged = true;
         } else {
@@ -177,8 +182,9 @@ async function fetchData() {
   );
 
   const selectedNote = await joplin.workspace.selectedNote();
+  const selectedNoteId = selectedNote ? selectedNote.id : null;
   const notes = await getNotes(
-    selectedNote.id,
+    selectedNoteId,
     maxNotes,
     maxDegree,
     filteredNotebookNames,
@@ -187,7 +193,7 @@ async function fetchData() {
     includeBacklinks
   );
 
-  return buildGraphData(notes, selectedNote.id, {
+  return buildGraphData(notes, selectedNoteId, {
     nodeFontSize: await joplin.settings.value("SETTING_NODE_FONT_SIZE"),
     nodeDistanceRatio:
       (await joplin.settings.value("SETTING_NODE_DISTANCE")) / 100.0,


### PR DESCRIPTION
`joplin.workspace.selectedNote()` returns null when nothing is selected, which happens whenever a notebook holding no notes is opened. Three places read `.id` or `.body` off it without checking, so opening an empty notebook threw `TypeError: Cannot read properties of null` out of the plugin and left the panel blank until another event rebuilt it.

The vendored `api/JoplinWorkspace.d.ts` types the return as `Promise<any>`, so nothing warned about it. The parameter types for the note id widen to `string | null` down through `getNotes`, `getLinkedNotes` and `buildGraphData` so the compiler carries the case from here on.

With no note selected the graph draws every note and focuses none, which is what a degree of zero already means. Above zero the graph is a traversal outward from the selected note, which has nowhere to start, so `getLinkedNotes` returns nothing rather than asking Joplin for a note called null and discarding the failure.

Verified against Joplin 3.6.16 in development mode: opening a notebook with no notes threw three times before and none after.

Based on #92.