### PR TITLE
Parse the notebook filter setting into names before matching

### DIFF
--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -9,7 +9,7 @@ import { getFilterFunction } from "./filter";
 /**
  * Collects notes from Joplin according to given parameters
  *
- * @param selectedNote ID of currently selected note, used when getting linked notes
+ * @param selectedNote ID of currently selected note, null when there is none, used when getting linked notes
  * @param maxNotes maximum notes to collect, used when getting all notes
  * @param maxDegree maximum distance away from the current note to get notes for, used when getting linked notes, set to 0 to get all notes
  * @param filteredNotebookNames comma separated string of notebooks to ***exclude***, values should be names
@@ -18,7 +18,7 @@ import { getFilterFunction } from "./filter";
  * @param includeBacklinks boolean toggle to also use backlinks to collect notes, used when getting linked notes
  */
 async function getNotes(
-    selectedNote: string,
+    selectedNote: string | null,
     maxNotes: number,
     maxDegree: number,
     filteredNotebookNames: string,

--- a/src/data/graph.test.ts
+++ b/src/data/graph.test.ts
@@ -72,3 +72,22 @@ describe("buildGraphData", () => {
     });
   });
 });
+
+describe("buildGraphData with no note selected", () => {
+  it("still draws every note", () => {
+    const data = buildGraphData(noteMap(note("a", ["b"]), note("b")), null, display);
+    expect(data.nodes.map((n) => n.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("still draws the links between them", () => {
+    const data = buildGraphData(noteMap(note("a", ["b"]), note("b")), null, display);
+    expect(edgeIds(data)).toEqual(["a->b"]);
+  });
+
+  it("focuses nothing", () => {
+    const notes = noteMap(note("a", ["b"]), note("b"));
+    const data = buildGraphData(notes, null, display);
+    expect(data.edges.some((e) => e.focused)).toBe(false);
+    expect(data.nodes.some((n) => n.focused)).toBe(false);
+  });
+});

--- a/src/data/graph.ts
+++ b/src/data/graph.ts
@@ -18,7 +18,7 @@ export interface Node {
 export interface GraphData {
   nodes: Node[];
   edges: Edge[];
-  currentNoteID: string;
+  currentNoteID: string | null;
   nodeFontSize: number;
   nodeDistanceRatio: number;
   showLinkDirection: boolean;
@@ -39,12 +39,12 @@ export interface DisplaySettings {
  * Flattens the collected notes into the node and edge lists the webview draws.
  *
  * @param notes notes to draw, keyed by id
- * @param selectedNoteId note Joplin has selected
+ * @param selectedNoteId note Joplin has selected, null when there is none
  * @param display drawing settings passed through to the webview
  */
 export function buildGraphData(
   notes: Map<string, Note>,
-  selectedNoteId: string,
+  selectedNoteId: string | null,
   display: DisplaySettings
 ): GraphData {
   const data: GraphData = {

--- a/src/data/notebooks.test.ts
+++ b/src/data/notebooks.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  getFilteredNotebooks,
   getNotebookChildren,
   getNotebooksByNameAndIDs,
   invertNotebookSelection,
 } from "./notebooks";
+import joplin from "api";
 import { Notebook } from "./types";
 
 function notebook(id: string, parent_id = ""): Notebook {
@@ -39,6 +41,21 @@ describe("getNotebooksByNameAndIDs", () => {
 
   it("matches nothing when no title matches", () => {
     expect(getNotebooksByNameAndIDs("Nowhere", all)).toEqual([]);
+  });
+
+  it("ignores the space after a comma", () => {
+    expect(ids(getNotebooksByNameAndIDs("Work, Personal", all))).toEqual([
+      "Personal",
+      "Work",
+    ]);
+  });
+
+  it("matches nothing for an empty filter string", () => {
+    expect(getNotebooksByNameAndIDs("", all)).toEqual([]);
+  });
+
+  it("matches nothing for a filter string of separators", () => {
+    expect(getNotebooksByNameAndIDs(" , , ", all)).toEqual([]);
   });
 });
 
@@ -95,5 +112,37 @@ describe("invertNotebookSelection", () => {
   it("returns nothing when everything is selected", () => {
     const all = [notebook("Work"), notebook("Personal")];
     expect(invertNotebookSelection(all, all)).toEqual([]);
+  });
+});
+
+describe("getFilteredNotebooks", () => {
+  const all = [notebook("Work"), notebook("Personal"), notebook("Archive")];
+
+  beforeEach(() => {
+    vi.mocked(joplin.data.get).mockReset();
+    vi.mocked(joplin.data.get).mockResolvedValue({
+      items: all,
+      has_more: false,
+    });
+  });
+
+  it("filters nothing when the filter string is empty in exclude mode", async () => {
+    expect(await getFilteredNotebooks("", false, false)).toEqual([]);
+  });
+
+  it("filters nothing when the filter string is empty in include mode", async () => {
+    // Inverting an empty selection would name every notebook, and the caller
+    // treats the result as notebooks to exclude, so the graph would be empty.
+    expect(await getFilteredNotebooks("", false, true)).toEqual([]);
+  });
+
+  it("excludes the named notebook in exclude mode", async () => {
+    const got = await getFilteredNotebooks("Work", false, false);
+    expect(got.map((n) => n.id)).toEqual(["Work"]);
+  });
+
+  it("excludes everything but the named notebook in include mode", async () => {
+    const got = await getFilteredNotebooks("Work", false, true);
+    expect(got.map((n) => n.id).sort()).toEqual(["Archive", "Personal"]);
   });
 });

--- a/src/data/notebooks.ts
+++ b/src/data/notebooks.ts
@@ -33,6 +33,12 @@ export async function getFilteredNotebooks(
   shouldFilterChildren: boolean,
   isIncludeFilter: boolean
 ): Promise<Notebook[]> {
+    // An empty setting names no notebooks. Inverting that would name every
+    // notebook, and the caller excludes whatever it is given.
+    if (splitFilterTerms(filterString).length === 0) {
+        return []
+    }
+
     const allNotebooks = await getNotebooks()
 
     let filteredNotebooks = getNotebooksByNameAndIDs(filterString, allNotebooks)
@@ -56,13 +62,25 @@ export function getNotebooksByNameAndIDs(
 
     let filteredNotebooks: Notebook[] = []
 
-    for (let text of filterText.split(",")) {
+    for (let text of splitFilterTerms(filterText)) {
         let notebooks = allNotebooks
           .filter(anb => anb.title == text)
         filteredNotebooks.push(...notebooks)
     }
 
     return filteredNotebooks
+}
+
+/**
+ * Splits the notebook filter setting into the names it holds.
+ *
+ * @param filterText the raw setting value
+ */
+export function splitFilterTerms(filterText: string): string[] {
+    return filterText
+      .split(",")
+      .map(term => term.trim())
+      .filter(term => term !== "")
 }
 
 export function getNotebookChildren(

--- a/src/data/notes.test.ts
+++ b/src/data/notes.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
-import { getAllLinksForNote } from "./notes";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getAllLinksForNote, getLinkedNotes } from "./notes";
+import { Note } from "./types";
+import joplin from "api";
 
 describe("getAllLinksForNote", () => {
   it("finds the target id of a markdown link", () => {
@@ -45,5 +47,23 @@ describe("getAllLinksForNote", () => {
 
   it("cannot tell a resource link from a note link", () => {
     expect(getAllLinksForNote("![shot](:/res456)")).toEqual(new Set(["res456"]));
+  });
+});
+
+describe("getLinkedNotes with no note selected", () => {
+  const keepAll = (nm: Map<string, Note>) => nm;
+
+  beforeEach(() => {
+    vi.mocked(joplin.data.get).mockReset();
+  });
+
+  it("collects no notes", async () => {
+    const notes = await getLinkedNotes(null, 1, false, keepAll);
+    expect(notes.size).toBe(0);
+  });
+
+  it("asks Joplin for nothing", async () => {
+    await getLinkedNotes(null, 1, false, keepAll);
+    expect(joplin.data.get).not.toHaveBeenCalled();
   });
 });

--- a/src/data/notes.ts
+++ b/src/data/notes.ts
@@ -41,13 +41,13 @@ export async function getAllNotes(
 /**
  * Fetch all notes linked to a given source note, up to a maximum degree of separation
  *
- * @param source_id ID of currently selected note
+ * @param source_id ID of currently selected note, null when there is none
  * @param maxDegree maximum distance away from the current note to get notes for
  * @param includeBacklinks boolean toggle to also use backlinks to collect notes
  * @param filterFunc filter function to exclude notes according to values used when it was created
  */
 export async function getLinkedNotes(
-  source_id: string,
+  source_id: string | null,
   maxDegree: number,
   includeBacklinks: boolean,
   filterFunc: (nm: Map<string, Note>) => Map<string, Note>
@@ -56,6 +56,12 @@ export async function getLinkedNotes(
   let visited = new Set();
   let noteMap = new Map();
   let degree = 0;
+
+  // A traversal outward from the selected note has nowhere to start when
+  // Joplin has no note selected.
+  if (source_id === null) {
+    return noteMap;
+  }
 
   pending.push(source_id);
   do {

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,9 @@ joplin.plugins.register({
       } else {
         if (eventName === "noteChange") {
           const selectedNote = await joplin.workspace.selectedNote();
-          var noteLinks = getAllLinksForNote(selectedNote.body);
+          var noteLinks = getAllLinksForNote(
+            selectedNote ? selectedNote.body : ""
+          );
           if (linksChanged(prevNoteLinks, noteLinks)) {
             prevNoteLinks = noteLinks;
             dataChanged = true;
@@ -111,15 +113,18 @@ joplin.plugins.register({
         } else if (eventName === "noteSelectionChange" && maxDegree == 0) {
           // noteSelectionChange should just re-center the graph, no need to fetch all new data and compare.
           const newlySelectedNote = await joplin.workspace.selectedNote();
-          data.currentNoteID = newlySelectedNote.id;
+          const newlySelectedNoteId = newlySelectedNote
+            ? newlySelectedNote.id
+            : null;
+          data.currentNoteID = newlySelectedNoteId;
           data.edges.forEach((edge) => {
             const shouldHaveFocus =
-              edge.source === newlySelectedNote.id ||
-              edge.target === newlySelectedNote.id;
+              edge.source === newlySelectedNoteId ||
+              edge.target === newlySelectedNoteId;
             edge.focused = shouldHaveFocus;
           });
           data.nodes.forEach((node) => {
-            node.focused = node.id === newlySelectedNote.id;
+            node.focused = node.id === newlySelectedNoteId;
           });
           dataChanged = true;
         } else {
@@ -177,8 +182,9 @@ async function fetchData() {
   );
 
   const selectedNote = await joplin.workspace.selectedNote();
+  const selectedNoteId = selectedNote ? selectedNote.id : null;
   const notes = await getNotes(
-    selectedNote.id,
+    selectedNoteId,
     maxNotes,
     maxDegree,
     filteredNotebookNames,
@@ -187,7 +193,7 @@ async function fetchData() {
     includeBacklinks
   );
 
-  return buildGraphData(notes, selectedNote.id, {
+  return buildGraphData(notes, selectedNoteId, {
     nodeFontSize: await joplin.settings.value("SETTING_NODE_FONT_SIZE"),
     nodeDistanceRatio:
       (await joplin.settings.value("SETTING_NODE_DISTANCE")) / 100.0,


### PR DESCRIPTION
The notebook filter setting was split on commas and matched against notebook titles without trimming, so "Work, Personal" never matched a notebook named Personal. Anyone writing the list the way it reads got a filter that silently did nothing for every name after the first.

Splitting also produced one empty name for an empty setting, which matched no notebook. In include mode that empty selection was then inverted into every notebook, and the caller excludes whatever it is handed, so the graph came out blank. Include mode with the filter left empty is the default-adjacent combination reported in #49, and it is now treated as no filter at all rather than as a request to show nothing.

Matching stays case sensitive. Notebook titles are strings the user typed into this same setting, Joplin allows two notebooks to share a title, and folding case would quietly widen an existing filter.

Closes #49.

Based on #93.