### PR TITLE
Filter notebooks nested more than two levels deep

### DIFF
--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -9,7 +9,7 @@ import { getFilterFunction } from "./filter";
 /**
  * Collects notes from Joplin according to given parameters
  *
- * @param selectedNote ID of currently selected note, used when getting linked notes
+ * @param selectedNote ID of currently selected note, null when there is none, used when getting linked notes
  * @param maxNotes maximum notes to collect, used when getting all notes
  * @param maxDegree maximum distance away from the current note to get notes for, used when getting linked notes, set to 0 to get all notes
  * @param filteredNotebookNames comma separated string of notebooks to ***exclude***, values should be names
@@ -18,7 +18,7 @@ import { getFilterFunction } from "./filter";
  * @param includeBacklinks boolean toggle to also use backlinks to collect notes, used when getting linked notes
  */
 async function getNotes(
-    selectedNote: string,
+    selectedNote: string | null,
     maxNotes: number,
     maxDegree: number,
     filteredNotebookNames: string,

--- a/src/data/graph.test.ts
+++ b/src/data/graph.test.ts
@@ -72,3 +72,22 @@ describe("buildGraphData", () => {
     });
   });
 });
+
+describe("buildGraphData with no note selected", () => {
+  it("still draws every note", () => {
+    const data = buildGraphData(noteMap(note("a", ["b"]), note("b")), null, display);
+    expect(data.nodes.map((n) => n.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("still draws the links between them", () => {
+    const data = buildGraphData(noteMap(note("a", ["b"]), note("b")), null, display);
+    expect(edgeIds(data)).toEqual(["a->b"]);
+  });
+
+  it("focuses nothing", () => {
+    const notes = noteMap(note("a", ["b"]), note("b"));
+    const data = buildGraphData(notes, null, display);
+    expect(data.edges.some((e) => e.focused)).toBe(false);
+    expect(data.nodes.some((n) => n.focused)).toBe(false);
+  });
+});

--- a/src/data/graph.ts
+++ b/src/data/graph.ts
@@ -18,7 +18,7 @@ export interface Node {
 export interface GraphData {
   nodes: Node[];
   edges: Edge[];
-  currentNoteID: string;
+  currentNoteID: string | null;
   nodeFontSize: number;
   nodeDistanceRatio: number;
   showLinkDirection: boolean;
@@ -39,12 +39,12 @@ export interface DisplaySettings {
  * Flattens the collected notes into the node and edge lists the webview draws.
  *
  * @param notes notes to draw, keyed by id
- * @param selectedNoteId note Joplin has selected
+ * @param selectedNoteId note Joplin has selected, null when there is none
  * @param display drawing settings passed through to the webview
  */
 export function buildGraphData(
   notes: Map<string, Note>,
-  selectedNoteId: string,
+  selectedNoteId: string | null,
   display: DisplaySettings
 ): GraphData {
   const data: GraphData = {

--- a/src/data/notebooks.test.ts
+++ b/src/data/notebooks.test.ts
@@ -91,6 +91,22 @@ describe("getNotebookChildren", () => {
     ]);
   });
 
+  it("adds descendants past the second generation", () => {
+    const all = [
+      notebook("Work"),
+      notebook("Projects", "Work"),
+      notebook("Alpha", "Projects"),
+      notebook("Deep", "Alpha"),
+      notebook("Personal"),
+    ];
+    expect(ids(getNotebookChildren([all[0]], all))).toEqual([
+      "Alpha",
+      "Deep",
+      "Projects",
+      "Work",
+    ]);
+  });
+
   it("does not repeat a notebook that is already selected", () => {
     const all = [notebook("Work"), notebook("Projects", "Work")];
     expect(ids(getNotebookChildren([all[0], all[1]], all))).toEqual([

--- a/src/data/notebooks.test.ts
+++ b/src/data/notebooks.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  getFilteredNotebooks,
   getNotebookChildren,
   getNotebooksByNameAndIDs,
   invertNotebookSelection,
 } from "./notebooks";
+import joplin from "api";
 import { Notebook } from "./types";
 
 function notebook(id: string, parent_id = ""): Notebook {
@@ -39,6 +41,21 @@ describe("getNotebooksByNameAndIDs", () => {
 
   it("matches nothing when no title matches", () => {
     expect(getNotebooksByNameAndIDs("Nowhere", all)).toEqual([]);
+  });
+
+  it("ignores the space after a comma", () => {
+    expect(ids(getNotebooksByNameAndIDs("Work, Personal", all))).toEqual([
+      "Personal",
+      "Work",
+    ]);
+  });
+
+  it("matches nothing for an empty filter string", () => {
+    expect(getNotebooksByNameAndIDs("", all)).toEqual([]);
+  });
+
+  it("matches nothing for a filter string of separators", () => {
+    expect(getNotebooksByNameAndIDs(" , , ", all)).toEqual([]);
   });
 });
 
@@ -95,5 +112,37 @@ describe("invertNotebookSelection", () => {
   it("returns nothing when everything is selected", () => {
     const all = [notebook("Work"), notebook("Personal")];
     expect(invertNotebookSelection(all, all)).toEqual([]);
+  });
+});
+
+describe("getFilteredNotebooks", () => {
+  const all = [notebook("Work"), notebook("Personal"), notebook("Archive")];
+
+  beforeEach(() => {
+    vi.mocked(joplin.data.get).mockReset();
+    vi.mocked(joplin.data.get).mockResolvedValue({
+      items: all,
+      has_more: false,
+    });
+  });
+
+  it("filters nothing when the filter string is empty in exclude mode", async () => {
+    expect(await getFilteredNotebooks("", false, false)).toEqual([]);
+  });
+
+  it("filters nothing when the filter string is empty in include mode", async () => {
+    // Inverting an empty selection would name every notebook, and the caller
+    // treats the result as notebooks to exclude, so the graph would be empty.
+    expect(await getFilteredNotebooks("", false, true)).toEqual([]);
+  });
+
+  it("excludes the named notebook in exclude mode", async () => {
+    const got = await getFilteredNotebooks("Work", false, false);
+    expect(got.map((n) => n.id)).toEqual(["Work"]);
+  });
+
+  it("excludes everything but the named notebook in include mode", async () => {
+    const got = await getFilteredNotebooks("Work", false, true);
+    expect(got.map((n) => n.id).sort()).toEqual(["Archive", "Personal"]);
   });
 });

--- a/src/data/notebooks.ts
+++ b/src/data/notebooks.ts
@@ -87,30 +87,20 @@ export function getNotebookChildren(
   notebooks: Notebook[],
   allNotebooks: Notebook[]
 ): Notebook[] {
-    // for every notebook, if
-    //   - it's parent is in the filter list
-    //   - it's not in the filter list itself
-    // are both true, then it's a direct child of the filtered NBs
-    let childrenOfFilteredNBs: Notebook[] =
-      allNotebooks
-        // if the NB already exists in the filtered NB IDs, exclude it
-        .filter(anb => ! notebooks.map(nb => nb.id).includes(anb.id))
-        // if NBs parent exists in the filtered NB IDs, include it
-        .filter(anb => notebooks.map(nb => nb.id).includes(anb.parent_id))
+    const selectedIds = new Set(notebooks.map(nb => nb.id))
 
-    let lastChildren = childrenOfFilteredNBs
-    while (childrenOfFilteredNBs.length > 0) {
-        notebooks = notebooks.concat(childrenOfFilteredNBs)
+    // Each pass collects the children of the generation found by the previous
+    // one, so a notebook is reached however deeply it is nested.
+    let generation = notebooks
+    while (generation.length > 0) {
+        const parentIds = new Set(generation.map(nb => nb.id))
 
-        // fetch next set of children not in the filter list
-        childrenOfFilteredNBs =
-          allNotebooks
-            .filter(anb => ! notebooks
-              .map(nb => nb.id)
-              .includes(anb.id))
-            .filter(anb => lastChildren
-              .map(nb => nb.id)
-              .includes(anb.parent_id))
+        generation = allNotebooks
+          .filter(anb => ! selectedIds.has(anb.id))
+          .filter(anb => parentIds.has(anb.parent_id))
+
+        generation.forEach(nb => selectedIds.add(nb.id))
+        notebooks = notebooks.concat(generation)
     }
 
     return notebooks

--- a/src/data/notebooks.ts
+++ b/src/data/notebooks.ts
@@ -33,6 +33,12 @@ export async function getFilteredNotebooks(
   shouldFilterChildren: boolean,
   isIncludeFilter: boolean
 ): Promise<Notebook[]> {
+    // An empty setting names no notebooks. Inverting that would name every
+    // notebook, and the caller excludes whatever it is given.
+    if (splitFilterTerms(filterString).length === 0) {
+        return []
+    }
+
     const allNotebooks = await getNotebooks()
 
     let filteredNotebooks = getNotebooksByNameAndIDs(filterString, allNotebooks)
@@ -56,13 +62,25 @@ export function getNotebooksByNameAndIDs(
 
     let filteredNotebooks: Notebook[] = []
 
-    for (let text of filterText.split(",")) {
+    for (let text of splitFilterTerms(filterText)) {
         let notebooks = allNotebooks
           .filter(anb => anb.title == text)
         filteredNotebooks.push(...notebooks)
     }
 
     return filteredNotebooks
+}
+
+/**
+ * Splits the notebook filter setting into the names it holds.
+ *
+ * @param filterText the raw setting value
+ */
+export function splitFilterTerms(filterText: string): string[] {
+    return filterText
+      .split(",")
+      .map(term => term.trim())
+      .filter(term => term !== "")
 }
 
 export function getNotebookChildren(

--- a/src/data/notes.test.ts
+++ b/src/data/notes.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
-import { getAllLinksForNote } from "./notes";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getAllLinksForNote, getLinkedNotes } from "./notes";
+import { Note } from "./types";
+import joplin from "api";
 
 describe("getAllLinksForNote", () => {
   it("finds the target id of a markdown link", () => {
@@ -45,5 +47,23 @@ describe("getAllLinksForNote", () => {
 
   it("cannot tell a resource link from a note link", () => {
     expect(getAllLinksForNote("![shot](:/res456)")).toEqual(new Set(["res456"]));
+  });
+});
+
+describe("getLinkedNotes with no note selected", () => {
+  const keepAll = (nm: Map<string, Note>) => nm;
+
+  beforeEach(() => {
+    vi.mocked(joplin.data.get).mockReset();
+  });
+
+  it("collects no notes", async () => {
+    const notes = await getLinkedNotes(null, 1, false, keepAll);
+    expect(notes.size).toBe(0);
+  });
+
+  it("asks Joplin for nothing", async () => {
+    await getLinkedNotes(null, 1, false, keepAll);
+    expect(joplin.data.get).not.toHaveBeenCalled();
   });
 });

--- a/src/data/notes.ts
+++ b/src/data/notes.ts
@@ -41,13 +41,13 @@ export async function getAllNotes(
 /**
  * Fetch all notes linked to a given source note, up to a maximum degree of separation
  *
- * @param source_id ID of currently selected note
+ * @param source_id ID of currently selected note, null when there is none
  * @param maxDegree maximum distance away from the current note to get notes for
  * @param includeBacklinks boolean toggle to also use backlinks to collect notes
  * @param filterFunc filter function to exclude notes according to values used when it was created
  */
 export async function getLinkedNotes(
-  source_id: string,
+  source_id: string | null,
   maxDegree: number,
   includeBacklinks: boolean,
   filterFunc: (nm: Map<string, Note>) => Map<string, Note>
@@ -56,6 +56,12 @@ export async function getLinkedNotes(
   let visited = new Set();
   let noteMap = new Map();
   let degree = 0;
+
+  // A traversal outward from the selected note has nowhere to start when
+  // Joplin has no note selected.
+  if (source_id === null) {
+    return noteMap;
+  }
 
   pending.push(source_id);
   do {

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,9 @@ joplin.plugins.register({
       } else {
         if (eventName === "noteChange") {
           const selectedNote = await joplin.workspace.selectedNote();
-          var noteLinks = getAllLinksForNote(selectedNote.body);
+          var noteLinks = getAllLinksForNote(
+            selectedNote ? selectedNote.body : ""
+          );
           if (linksChanged(prevNoteLinks, noteLinks)) {
             prevNoteLinks = noteLinks;
             dataChanged = true;
@@ -111,15 +113,18 @@ joplin.plugins.register({
         } else if (eventName === "noteSelectionChange" && maxDegree == 0) {
           // noteSelectionChange should just re-center the graph, no need to fetch all new data and compare.
           const newlySelectedNote = await joplin.workspace.selectedNote();
-          data.currentNoteID = newlySelectedNote.id;
+          const newlySelectedNoteId = newlySelectedNote
+            ? newlySelectedNote.id
+            : null;
+          data.currentNoteID = newlySelectedNoteId;
           data.edges.forEach((edge) => {
             const shouldHaveFocus =
-              edge.source === newlySelectedNote.id ||
-              edge.target === newlySelectedNote.id;
+              edge.source === newlySelectedNoteId ||
+              edge.target === newlySelectedNoteId;
             edge.focused = shouldHaveFocus;
           });
           data.nodes.forEach((node) => {
-            node.focused = node.id === newlySelectedNote.id;
+            node.focused = node.id === newlySelectedNoteId;
           });
           dataChanged = true;
         } else {
@@ -177,8 +182,9 @@ async function fetchData() {
   );
 
   const selectedNote = await joplin.workspace.selectedNote();
+  const selectedNoteId = selectedNote ? selectedNote.id : null;
   const notes = await getNotes(
-    selectedNote.id,
+    selectedNoteId,
     maxNotes,
     maxDegree,
     filteredNotebookNames,
@@ -187,7 +193,7 @@ async function fetchData() {
     includeBacklinks
   );
 
-  return buildGraphData(notes, selectedNote.id, {
+  return buildGraphData(notes, selectedNoteId, {
     nodeFontSize: await joplin.settings.value("SETTING_NODE_FONT_SIZE"),
     nodeDistanceRatio:
       (await joplin.settings.value("SETTING_NODE_DISTANCE")) / 100.0,


### PR DESCRIPTION
Filtering a notebook with "Filter child notebooks" enabled reached its children and grandchildren, then stopped. A note three levels down stayed in the graph even though the notebook holding it descends from the filtered one.

The loop searched for the children of each new generation, but the variable naming the generation to search from was assigned once before the loop and never reassigned, so every pass after the first looked for the children of the first generation again. Those were already collected, the search came back empty, and the loop ended. Each pass now searches from the generation the previous pass found.

The collected ids are tracked in a `Set` rather than by rebuilding an array of ids for every comparison, which also stops a notebook being visited twice if the notebook tree ever contains a cycle.

Verified against Joplin 3.6.16 in development mode with a four level notebook tree: the note in the deepest notebook survived the filter before and is excluded after.

Based on #94.