### PR TITLE
[67] Collect note links from reference-style link definitions

### DIFF
--- a/src/data/notes.test.ts
+++ b/src/data/notes.test.ts
@@ -48,6 +48,45 @@ describe("getAllLinksForNote", () => {
   it("cannot tell a resource link from a note link", () => {
     expect(getAllLinksForNote("![shot](:/res456)")).toEqual(new Set(["res456"]));
   });
+
+  it("finds the target id of a link reference definition", () => {
+    const body = "see [Other][ref]\n\n[ref]: :/abc123";
+    expect(getAllLinksForNote(body)).toEqual(new Set(["abc123"]));
+  });
+
+  it("ignores the title trailing a link reference definition", () => {
+    expect(getAllLinksForNote('[ref]: :/abc123 "Other"')).toEqual(
+      new Set(["abc123"])
+    );
+  });
+
+  it("unwraps an angle-bracketed link reference definition", () => {
+    expect(getAllLinksForNote("[ref]: <:/abc123>")).toEqual(new Set(["abc123"]));
+  });
+
+  it("allows a link reference definition to be indented three spaces", () => {
+    expect(getAllLinksForNote("   [ref]: :/abc123")).toEqual(
+      new Set(["abc123"])
+    );
+  });
+
+  it("ignores a link reference definition pointing outside Joplin", () => {
+    expect(getAllLinksForNote("[ref]: https://example.com")).toEqual(new Set());
+  });
+
+  it("ignores a bracketed label followed by a colon mid-line", () => {
+    expect(getAllLinksForNote("prose [ref]: :/abc123")).toEqual(new Set());
+  });
+
+  it("collects both inline links and link reference definitions", () => {
+    const body = "[One](:/aaa) and [Two][ref]\n\n[ref]: :/bbb";
+    expect(getAllLinksForNote(body)).toEqual(new Set(["aaa", "bbb"]));
+  });
+
+  it("collapses an inline link and a definition naming the same note", () => {
+    const body = "[One](:/aaa) and [Again][ref]\n\n[ref]: :/aaa";
+    expect(getAllLinksForNote(body)).toEqual(new Set(["aaa"]));
+  });
 });
 
 describe("getLinkedNotes with no note selected", () => {

--- a/src/data/notes.ts
+++ b/src/data/notes.ts
@@ -130,14 +130,20 @@ export function getAllLinksForNote(noteBody: string): Set<string> {
     // TODO: needs to handle resource links vs note links. see 4. Tips note for
     // webclipper screenshot.
     // https://stackoverflow.com/questions/37462126/regex-match-markdown-link
-    const linkRegexp = /\[\]|\[.*?\]\(:\/(.*?)\)/g;
-    var match = null;
-    do {
-        match = linkRegexp.exec(noteBody);
-        if (match != null && match[1] !== undefined) {
-            links.add(match[1]);
-        }
-    } while (match != null);
+    const inlineLinkRegexp = /\[\]|\[.*?\]\(:\/(.*?)\)/g;
+    // A link reference definition, `[label]: :/id "title"`, which CommonMark
+    // lets start up to three spaces in and wrap its destination in angle
+    // brackets. https://spec.commonmark.org/0.31.2/#link-reference-definition
+    const definitionRegexp = /^ {0,3}\[[^\]]+\]:[ \t]*<?:\/([^\s<>]+)>?/gm;
+    for (const regexp of [inlineLinkRegexp, definitionRegexp]) {
+        var match = null;
+        do {
+            match = regexp.exec(noteBody);
+            if (match != null && match[1] !== undefined) {
+                links.add(match[1]);
+            }
+        } while (match != null);
+    }
     return links;
 }
 


### PR DESCRIPTION
A note that declares its link destinations at the end of the body, in CommonMark reference style (`[label]: :/noteid`), draws no graph edges. Collecting every reference definition whose destination is a Joplin note fixes that, including a definition that no label in the body references. A definition placing its destination on the line after the colon, which the [spec](https://spec.commonmark.org/0.31.2/#link-reference-definition) permits, stays unmatched.

Closes #67