### PR TITLE
[85] Ignore backlinks from notes whose titles are on the exclusion list

### DIFF
--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -1,7 +1,8 @@
 import { Note } from "./types";
 import {
   getAllNotes,
-  getLinkedNotes
+  getLinkedNotes,
+  getNoteIdsByTitle
 } from "./notes";
 import { getFilterFunction } from "./filter";
 // every function required by index.ts is listed here
@@ -16,6 +17,7 @@ import { getFilterFunction } from "./filter";
  * @param shouldFilterChildren boolean toggle to also include notebooks that are the children of those in the filter
  * @param isIncludeFilter boolean toggle to invert selected notebooks (default value is `false` to exclude, set to `true` to use filter values for inclusion)
  * @param includeBacklinks boolean toggle to also use backlinks to collect notes, used when getting linked notes
+ * @param excludedBacklinkNoteTitles comma separated string of note titles whose backlinks are ignored, values should be titles
  */
 async function getNotes(
     selectedNote: string | null,
@@ -24,7 +26,8 @@ async function getNotes(
     filteredNotebookNames: string,
     shouldFilterChildren: boolean,
     isIncludeFilter: boolean,
-    includeBacklinks: boolean
+    includeBacklinks: boolean,
+    excludedBacklinkNoteTitles: string
 ): Promise<Map<string, Note>> {
   let notes = new Map<string, Note>();
 
@@ -35,10 +38,15 @@ async function getNotes(
   )
   
   if (maxDegree > 0) {
+    const excludedBacklinkNoteIds = includeBacklinks
+      ? await getNoteIdsByTitle(excludedBacklinkNoteTitles)
+      : new Set<string>()
+
     notes = await getLinkedNotes(
       selectedNote,
       maxDegree,
       includeBacklinks,
+      excludedBacklinkNoteIds,
       filterFunc
     )
   } else {

--- a/src/data/notes.test.ts
+++ b/src/data/notes.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getAllLinksForNote, getLinkedNotes } from "./notes";
-import { Note } from "./types";
+import {
+  getAllBacklinksForNote,
+  getAllLinksForNote,
+  getLinkedNotes,
+  getNoteIdsByTitle,
+} from "./notes";
+import { JoplinNote, Note } from "./types";
 import joplin from "api";
 
 describe("getAllLinksForNote", () => {
@@ -58,12 +63,218 @@ describe("getLinkedNotes with no note selected", () => {
   });
 
   it("collects no notes", async () => {
-    const notes = await getLinkedNotes(null, 1, false, keepAll);
+    const notes = await getLinkedNotes(null, 1, false, new Set(), keepAll);
     expect(notes.size).toBe(0);
   });
 
   it("asks Joplin for nothing", async () => {
-    await getLinkedNotes(null, 1, false, keepAll);
+    await getLinkedNotes(null, 1, false, new Set(), keepAll);
     expect(joplin.data.get).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Answers a `["search"]` call with a single unpaginated page of the given items.
+ */
+function mockSearchResults(items: object[]) {
+  vi.mocked(joplin.data.get).mockResolvedValue({ items, has_more: false });
+}
+
+describe("getNoteIdsByTitle", () => {
+  beforeEach(() => {
+    vi.mocked(joplin.data.get).mockReset();
+  });
+
+  it("resolves a listed title to the id of the note carrying it", async () => {
+    mockSearchResults([{ id: "hist", title: "History" }]);
+    expect(await getNoteIdsByTitle("History")).toEqual(new Set(["hist"]));
+  });
+
+  it("asks Joplin for the title as a quoted phrase", async () => {
+    mockSearchResults([]);
+    await getNoteIdsByTitle("Daily Log");
+    expect(joplin.data.get).toHaveBeenCalledWith(
+      ["search"],
+      expect.objectContaining({ query: 'title:"Daily Log"' })
+    );
+  });
+
+  it("drops a note whose title merely starts with the listed title", async () => {
+    mockSearchResults([
+      { id: "hist", title: "History" },
+      { id: "rome", title: "History of Rome" },
+    ]);
+    expect(await getNoteIdsByTitle("History")).toEqual(new Set(["hist"]));
+  });
+
+  it("resolves every title in a comma separated list", async () => {
+    vi.mocked(joplin.data.get)
+      .mockResolvedValueOnce({
+        items: [{ id: "hist", title: "History" }],
+        has_more: false,
+      })
+      .mockResolvedValueOnce({
+        items: [{ id: "log", title: "Daily Log" }],
+        has_more: false,
+      });
+    expect(await getNoteIdsByTitle("History, Daily Log")).toEqual(
+      new Set(["hist", "log"])
+    );
+    expect(joplin.data.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns the ids of every note sharing a listed title", async () => {
+    mockSearchResults([
+      { id: "hist1", title: "History" },
+      { id: "hist2", title: "History" },
+    ]);
+    expect(await getNoteIdsByTitle("History")).toEqual(
+      new Set(["hist1", "hist2"])
+    );
+  });
+
+  it("returns an empty set when a listed title matches no note", async () => {
+    mockSearchResults([]);
+    expect(await getNoteIdsByTitle("History")).toEqual(new Set());
+  });
+
+  it("asks Joplin for nothing when the setting is empty", async () => {
+    expect(await getNoteIdsByTitle("")).toEqual(new Set());
+    expect(joplin.data.get).not.toHaveBeenCalled();
+  });
+
+  it("asks Joplin for nothing when the setting holds only separators", async () => {
+    expect(await getNoteIdsByTitle(" , , ")).toEqual(new Set());
+    expect(joplin.data.get).not.toHaveBeenCalled();
+  });
+
+  it("collects ids from every page the search reports", async () => {
+    vi.mocked(joplin.data.get)
+      .mockResolvedValueOnce({
+        items: [{ id: "hist1", title: "History" }],
+        has_more: true,
+      })
+      .mockResolvedValueOnce({
+        items: [{ id: "hist2", title: "History" }],
+        has_more: false,
+      });
+    expect(await getNoteIdsByTitle("History")).toEqual(
+      new Set(["hist1", "hist2"])
+    );
+  });
+});
+
+describe("getAllBacklinksForNote", () => {
+  beforeEach(() => {
+    vi.mocked(joplin.data.get).mockReset();
+  });
+
+  it("returns the ids of the notes the search reports", async () => {
+    mockSearchResults([{ id: "a" }, { id: "b" }]);
+    expect(await getAllBacklinksForNote("target", new Set())).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("drops an excluded id", async () => {
+    mockSearchResults([{ id: "a" }, { id: "hist" }]);
+    expect(await getAllBacklinksForNote("target", new Set(["hist"]))).toEqual([
+      "a",
+    ]);
+  });
+
+  it("returns nothing when every linking note is excluded", async () => {
+    mockSearchResults([{ id: "hist" }]);
+    expect(await getAllBacklinksForNote("target", new Set(["hist"]))).toEqual(
+      []
+    );
+  });
+});
+
+describe("getLinkedNotes with excluded backlinks", () => {
+  const keepAll = (nm: Map<string, Note>) => nm;
+
+  /**
+   * Answers the two endpoints the traversal uses.
+   *
+   * @param notes notes Joplin holds
+   * @param backlinks ids of the notes linking to each note, keyed by note id
+   */
+  function mockVault(
+    notes: JoplinNote[],
+    backlinks: { [noteId: string]: string[] }
+  ) {
+    const notesById = new Map(notes.map((note) => [note.id, note]));
+    vi.mocked(joplin.data.get).mockImplementation(
+      async (path: string[], query: any) => {
+        if (path[0] === "notes") {
+          return { ...notesById.get(path[1]) };
+        }
+        return {
+          items: (backlinks[query.query] ?? []).map((id) => ({ id })),
+          has_more: false,
+        };
+      }
+    );
+  }
+
+  const note = (id: string, body = ""): JoplinNote => ({
+    id,
+    parent_id: "notebook",
+    title: id,
+    body,
+  });
+
+  beforeEach(() => {
+    vi.mocked(joplin.data.get).mockReset();
+  });
+
+  it("leaves out a note that only reaches the graph as an excluded backlink", async () => {
+    mockVault([note("selected"), note("hist", "[s](:/selected)")], {
+      selected: ["hist"],
+    });
+    const notes = await getLinkedNotes(
+      "selected",
+      1,
+      true,
+      new Set(["hist"]),
+      keepAll
+    );
+    expect([...notes.keys()]).toEqual(["selected"]);
+  });
+
+  it("keeps a note reached as a backlink when nothing is excluded", async () => {
+    mockVault([note("selected"), note("hist", "[s](:/selected)")], {
+      selected: ["hist"],
+    });
+    const notes = await getLinkedNotes("selected", 1, true, new Set(), keepAll);
+    expect([...notes.keys()].sort()).toEqual(["hist", "selected"]);
+  });
+
+  it("keeps an excluded note that a note in the graph links to", async () => {
+    mockVault([note("selected", "[h](:/hist)"), note("hist")], {});
+    const notes = await getLinkedNotes(
+      "selected",
+      1,
+      true,
+      new Set(["hist"]),
+      keepAll
+    );
+    expect([...notes.keys()].sort()).toEqual(["hist", "selected"]);
+  });
+
+  it("keeps the selected note when its own title is excluded", async () => {
+    mockVault([note("hist"), note("other", "[h](:/hist)")], {
+      hist: ["other"],
+    });
+    const notes = await getLinkedNotes(
+      "hist",
+      1,
+      true,
+      new Set(["hist"]),
+      keepAll
+    );
+    expect(notes.get("hist").distanceToCurrentNote).toBe(0);
   });
 });

--- a/src/data/notes.ts
+++ b/src/data/notes.ts
@@ -1,6 +1,7 @@
 import joplin from "api";
 import { JoplinNote, Note, Tag } from "./types"
 import { buildNote } from "./utils"
+import { splitFilterTerms } from "./notebooks"
 
 // Functions to do with getting notes or notes metadata goes here
 
@@ -44,12 +45,14 @@ export async function getAllNotes(
  * @param source_id ID of currently selected note, null when there is none
  * @param maxDegree maximum distance away from the current note to get notes for
  * @param includeBacklinks boolean toggle to also use backlinks to collect notes
+ * @param excludedBacklinkNoteIds ids of the notes whose backlinks are ignored
  * @param filterFunc filter function to exclude notes according to values used when it was created
  */
 export async function getLinkedNotes(
   source_id: string | null,
   maxDegree: number,
   includeBacklinks: boolean,
+  excludedBacklinkNoteIds: Set<string>,
   filterFunc: (nm: Map<string, Note>) => Map<string, Note>
 ): Promise<Map<string, Note>> {
   let pending = [];
@@ -86,7 +89,9 @@ export async function getLinkedNotes(
       if (noteMap.has(joplinNote.id)) {
         const allLinks = [
           ...note.links, // these are the forward-links
-          ...(includeBacklinks ? await getAllBacklinksForNote(note.id) : []),
+          ...(includeBacklinks
+            ? await getAllBacklinksForNote(note.id, excludedBacklinkNoteIds)
+            : []),
         ];
 
         // stash any new links for the next iteration
@@ -141,7 +146,16 @@ export function getAllLinksForNote(noteBody: string): Set<string> {
     return links;
 }
 
-export async function getAllBacklinksForNote(noteId: string) {
+/**
+ * Collects the ids of the notes linking to a given note.
+ *
+ * @param noteId id of the note to collect links to
+ * @param excludedNoteIds ids of the notes whose links to it are ignored
+ */
+export async function getAllBacklinksForNote(
+  noteId: string,
+  excludedNoteIds: Set<string>
+) {
     const links: string[] = [];
     let pageNum = 1;
     let response;
@@ -151,9 +165,45 @@ export async function getAllBacklinksForNote(noteId: string) {
             fields: ["id"],
             page: pageNum++,
         });
-        links.push(...response.items.map(({ id }) => id));
+        links.push(
+          ...response.items
+            .map(({ id }) => id)
+            .filter((id) => !excludedNoteIds.has(id))
+        );
     } while (response.has_more);
     return links;
+}
+
+/**
+ * Resolves note titles to the ids of the notes carrying them.
+ *
+ * The title is searched as a quoted phrase so that a colon in it is not read as
+ * a field query, and each hit is compared for equality because Joplin matches a
+ * title word by word: a longer title containing the searched one comes back too.
+ *
+ * @param titleFilterString comma separated string of note titles
+ */
+export async function getNoteIdsByTitle(
+  titleFilterString: string
+): Promise<Set<string>> {
+    const noteIds = new Set<string>();
+
+    for (const title of splitFilterTerms(titleFilterString)) {
+        let pageNum = 1;
+        let response;
+        do {
+            response = await joplin.data.get(["search"], {
+                query: `title:"${title}"`,
+                fields: ["id", "title"],
+                page: pageNum++,
+            });
+            response.items
+              .filter((item) => item.title === title)
+              .forEach((item) => noteIds.add(item.id));
+        } while (response.has_more);
+    }
+
+    return noteIds;
 }
 
 export async function getNoteTags(noteId: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,6 +177,9 @@ async function fetchData() {
   const includeBacklinks = await joplin.settings.value(
     "SETTING_INCLUDE_BACKLINKS"
   );
+  const excludedBacklinkNoteTitles = await joplin.settings.value(
+    "SETTING_NOTE_TITLES_TO_EXCLUDE_FROM_BACKLINKS"
+  );
   const showLinkDirection = await joplin.settings.value(
     "SETTING_SHOW_LINK_DIRECTION"
   );
@@ -190,7 +193,8 @@ async function fetchData() {
     filteredNotebookNames,
     shouldFilterChildren,
     isIncludeFilter,
-    includeBacklinks
+    includeBacklinks,
+    excludedBacklinkNoteTitles
   );
 
   return buildGraphData(notes, selectedNoteId, {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -91,6 +91,15 @@ export async function registerSettings() {
       description:
         "Backlinks are links that other notes have to the selected note. Note: This setting is targeted towards selection-based graphs with degree of separation > 0.",
     },
+    SETTING_NOTE_TITLES_TO_EXCLUDE_FROM_BACKLINKS: {
+      value: "",
+      type: SettingItemType.String,
+      section: sectionName,
+      public: true,
+      label: "Note titles to exclude from backlinks",
+      description:
+        "Comma separated list of note titles. Backlinks from these notes are ignored, so a note that links to everything, such as a history log, does not pull the whole graph in. Only applies when backlinks are included.",
+    },
     SETTING_SHOW_LINK_DIRECTION: {
       value: DEFAULT_SHOW_LINK_DIRECTION,
       type: SettingItemType.Bool,


### PR DESCRIPTION
A note that logs every note the user visits, such as the History Panel plugin's log, links to the whole vault. With backlinks turned on, selecting any note pulls that log in, and traversal then spreads to everything. Listing the log's title under "Note titles to exclude from backlinks" drops it from other notes' backlink results.

The exclusion covers backlinks only: a listed note still appears when a note already in the graph links to it, and whole-graph mode is unaffected. Titles are compared for equality against Joplin's word-by-word search results (https://joplinapp.org/help/apps/search/), and a title containing a double quote excludes nothing.

Closes #85