### PR TITLE
[39] Skip graph updates while the graph panel is hidden

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+
+const SETTINGS = {
+  SETTING_MAX_SEPARATION_DEGREE: 0,
+  SETTING_MAX_NODES: 100,
+  SETTING_NOTEBOOK_NAMES_TO_FILTER: "",
+  SETTING_FILTER_CHILD_NOTEBOOKS: false,
+  SETTING_FILTER_IS_INCLUDE_FILTER: "exclude",
+  SETTING_INCLUDE_BACKLINKS: false,
+  SETTING_NOTE_TITLES_TO_EXCLUDE_FROM_BACKLINKS: "",
+  SETTING_SHOW_LINK_DIRECTION: false,
+  SETTING_NODE_FONT_SIZE: 20,
+  SETTING_NODE_DISTANCE: 100,
+};
+
+function notesPage(...titles: string[]) {
+  return {
+    items: titles.map((title, index) => ({
+      id: `note-${index}`,
+      parent_id: "notebook",
+      title: title,
+      body: "",
+    })),
+    has_more: false,
+  };
+}
+
+// The workspace and settings handlers call updateUI without awaiting it, so a
+// test has to let the pending promise chain drain before asserting.
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+async function startPlugin() {
+  vi.resetModules();
+  const stub = await import("../test/joplin-stub");
+  vi.mocked(stub.default.settings.value).mockImplementation(
+    async (key: string) => SETTINGS[key]
+  );
+  vi.mocked(stub.default.workspace.selectedNote).mockResolvedValue(null);
+  vi.mocked(stub.default.data.get).mockResolvedValue(notesPage("A"));
+  await import("./index");
+  await stub.captured.onStart();
+  return stub;
+}
+
+describe("updateUI", () => {
+  it("reads no notes while the panel is hidden", async () => {
+    const stub = await startPlugin();
+    stub.setPanelVisible(false);
+    vi.mocked(stub.default.data.get).mockClear();
+
+    stub.captured.workspaceHandlers.noteSelectionChange();
+    stub.captured.workspaceHandlers.syncComplete();
+    stub.captured.settingsChangeHandler();
+    await flush();
+
+    expect(stub.default.data.get).not.toHaveBeenCalled();
+  });
+
+  it("reads notes while the panel is visible", async () => {
+    const stub = await startPlugin();
+    stub.setPanelVisible(true);
+    vi.mocked(stub.default.data.get).mockClear();
+
+    stub.captured.workspaceHandlers.syncComplete();
+    await flush();
+
+    expect(stub.default.data.get).toHaveBeenCalled();
+  });
+
+  it("runs the refresh owed from a hidden panel once the panel is shown", async () => {
+    const stub = await startPlugin();
+    stub.setPanelVisible(false);
+    stub.captured.workspaceHandlers.syncComplete();
+    await flush();
+    vi.mocked(stub.default.data.get).mockClear();
+
+    await stub.captured.commands.get("showHideGraphUI").execute();
+
+    expect(stub.default.data.get).toHaveBeenCalled();
+
+    vi.mocked(stub.default.data.get).mockClear();
+    await stub.captured.commands.get("showHideGraphUI").execute();
+    await stub.captured.commands.get("showHideGraphUI").execute();
+
+    expect(stub.default.data.get).not.toHaveBeenCalled();
+  });
+});
+
+describe("the poll message", () => {
+  it("resolves a pending poll with the next model change", async () => {
+    const stub = await startPlugin();
+    stub.setPanelVisible(true);
+
+    const poll = stub.captured.panelMessageHandler({ name: "poll" });
+    stub.captured.workspaceHandlers.syncComplete();
+    await flush();
+    const modelChange = await poll;
+
+    expect(modelChange.name).toEqual("syncComplete");
+    expect(modelChange.data.nodes.map((node) => node.title)).toEqual(["A"]);
+  });
+});
+
+describe("the update message", () => {
+  it("answers with freshly fetched data", async () => {
+    const stub = await startPlugin();
+    stub.captured.workspaceHandlers.syncComplete();
+    await flush();
+    vi.mocked(stub.default.data.get).mockResolvedValue(notesPage("A", "B"));
+
+    const response = await stub.captured.panelMessageHandler({
+      name: "update",
+    });
+
+    expect(response.data.nodes.map((node) => node.title)).toEqual(["A", "B"]);
+
+    await stub.captured.panelMessageHandler({ name: "poll" });
+    let modelChange;
+    stub.captured
+      .panelMessageHandler({ name: "poll" })
+      .then((change) => (modelChange = change));
+    stub.captured.workspaceHandlers.syncComplete();
+    await flush();
+
+    expect(modelChange).toBeUndefined();
+  });
+
+  it("reads no notes while the panel is hidden", async () => {
+    const stub = await startPlugin();
+    stub.setPanelVisible(false);
+    vi.mocked(stub.default.data.get).mockClear();
+
+    await stub.captured.panelMessageHandler({ name: "update" });
+
+    expect(stub.default.data.get).not.toHaveBeenCalled();
+  });
+
+  it("leaves a refresh owed while the panel is hidden", async () => {
+    const stub = await startPlugin();
+    stub.setPanelVisible(false);
+    await stub.captured.panelMessageHandler({ name: "update" });
+    vi.mocked(stub.default.data.get).mockClear();
+
+    await stub.captured.commands.get("showHideGraphUI").execute();
+
+    expect(stub.default.data.get).toHaveBeenCalled();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ joplin.plugins.register({
     var prevData = {};
     var prevNoteLinks: Set<string>;
     var syncOngoing = false;
+    var refreshOwed = false;
 
     async function drawPanel() {
       await panels.setHtml(
@@ -45,7 +46,10 @@ joplin.plugins.register({
       iconName: "fas fa-sitemap",
       execute: async () => {
         const isVisible = await (panels as any).visible(view);
-        (panels as any).show(view, !isVisible);
+        await (panels as any).show(view, !isVisible);
+        if (!isVisible && refreshOwed) {
+          await updateUI("showGraphUI");
+        }
       },
     });
     await joplin.views.toolbarButtons.create(
@@ -65,7 +69,7 @@ joplin.plugins.register({
     await panels.addScript(view, "./webview.css");
     await panels.addScript(view, "./ui/index.js");
 
-    panels.onMessage(view, (message: any) => {
+    panels.onMessage(view, async (message: any) => {
       switch (message.name) {
         case "poll":
           let p = new Promise((resolve) => {
@@ -73,7 +77,15 @@ joplin.plugins.register({
           });
           notifyUI();
           return p;
+        // A hidden panel keeps its webview mounted and sending this message, so the
+        // fetch is gated on visibility here as well as in updateUI (https://github.com/laurent22/joplin/blob/v3.6.16/packages/app-desktop/gui/ResizableLayout/LayoutItemContainer.tsx#L22-L25).
         case "update":
+          if (!(await (panels as any).visible(view))) {
+            refreshOwed = true;
+            return { name: "update", data: data };
+          }
+          data = await fetchData();
+          prevData = data;
           return { name: "update", data: data };
         case "navigateTo":
           joplin.commands.execute("openNote", message.id);
@@ -91,6 +103,12 @@ joplin.plugins.register({
       if (syncOngoing) {
         return;
       }
+
+      if (!(await (panels as any).visible(view))) {
+        refreshOwed = true;
+        return;
+      }
+      refreshOwed = false;
 
       const maxDegree = await joplin.settings.value(
         "SETTING_MAX_SEPARATION_DEGREE"

--- a/test/joplin-stub.ts
+++ b/test/joplin-stub.ts
@@ -1,12 +1,85 @@
 import { vi } from "vitest";
 
+interface RegisteredCommand {
+  name: string;
+  execute: (...args: any[]) => any;
+}
+
+type Handler = (...args: any[]) => any;
+
+/**
+ * Everything src/index.ts hands to Joplin during onStart, so a test can drive
+ * the plugin the way Joplin would.
+ */
+export const captured = {
+  onStart: undefined as Handler | undefined,
+  commands: new Map<string, RegisteredCommand>(),
+  panelMessageHandler: undefined as Handler | undefined,
+  workspaceHandlers: {} as Record<string, Handler>,
+  settingsChangeHandler: undefined as Handler | undefined,
+};
+
+let panelVisible = true;
+
+export function setPanelVisible(visible: boolean) {
+  panelVisible = visible;
+}
+
 // Stands in for the `api` module under test. The real api/index.ts declares
 // `joplin` as an ambient global, so importing it outside Joplin throws.
 const joplin = {
   data: { get: vi.fn() },
-  settings: { value: vi.fn(), setValue: vi.fn() },
-  workspace: { selectedNote: vi.fn() },
-  commands: { execute: vi.fn() },
+  settings: {
+    value: vi.fn(),
+    setValue: vi.fn(),
+    registerSection: vi.fn(async () => {}),
+    registerSettings: vi.fn(async () => {}),
+    onChange: vi.fn(async (handler: Handler) => {
+      captured.settingsChangeHandler = handler;
+    }),
+  },
+  workspace: {
+    selectedNote: vi.fn(),
+    onNoteChange: vi.fn(async (handler: Handler) => {
+      captured.workspaceHandlers.noteChange = handler;
+    }),
+    onNoteSelectionChange: vi.fn(async (handler: Handler) => {
+      captured.workspaceHandlers.noteSelectionChange = handler;
+    }),
+    onSyncStart: vi.fn(async (handler: Handler) => {
+      captured.workspaceHandlers.syncStart = handler;
+    }),
+    onSyncComplete: vi.fn(async (handler: Handler) => {
+      captured.workspaceHandlers.syncComplete = handler;
+    }),
+  },
+  commands: {
+    execute: vi.fn(),
+    register: vi.fn(async (command: RegisteredCommand) => {
+      captured.commands.set(command.name, command);
+    }),
+  },
+  plugins: {
+    register: vi.fn(async (plugin: { onStart: Handler }) => {
+      captured.onStart = plugin.onStart;
+    }),
+  },
+  views: {
+    panels: {
+      create: vi.fn(async (id: string) => id),
+      setHtml: vi.fn(async () => {}),
+      addScript: vi.fn(async () => {}),
+      onMessage: vi.fn((handle: string, handler: Handler) => {
+        captured.panelMessageHandler = handler;
+      }),
+      show: vi.fn(async (handle: string, show = true) => {
+        panelVisible = show;
+      }),
+      visible: vi.fn(async () => panelVisible),
+    },
+    toolbarButtons: { create: vi.fn(async () => {}) },
+    menuItems: { create: vi.fn(async () => {}) },
+  },
 };
 
 export default joplin;

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,8 +4,18 @@ const { defineConfig } = require("vitest/config");
 module.exports = defineConfig({
   resolve: {
     // The real api/index.ts declares `joplin` as an ambient global, so importing
-    // it outside Joplin throws. Every module under src/data reaches it.
-    alias: { api: path.resolve(__dirname, "test/joplin-stub.ts") },
+    // it outside Joplin throws. Every module under src reaches it. api/types.ts
+    // is plain type and enum declarations, so it loads as it ships.
+    alias: [
+      {
+        find: /^api\/types$/,
+        replacement: path.resolve(__dirname, "api/types.ts"),
+      },
+      {
+        find: /^api$/,
+        replacement: path.resolve(__dirname, "test/joplin-stub.ts"),
+      },
+    ],
   },
   test: {
     include: ["src/**/*.test.ts"],


### PR DESCRIPTION
Switching notes, completing a sync, or changing a setting collected the whole note graph even when the panel was closed, which contributes to the lag reported in #39.

A hidden panel keeps its webview mounted at [`display: none`](https://github.com/laurent22/joplin/blob/v3.6.16/packages/app-desktop/gui/ResizableLayout/LayoutItemContainer.tsx#L22-L25) and goes on sending the `update` message it emits once per script load, so that message and the workspace event path are both gated on `panels.visible`. An update skipped while hidden is recorded and replayed the next time the panel is shown, which also fills the graph on first open instead of leaving it blank.

The gate does nothing on mobile, where dismissing the plugin panel dialog sets a separate flag and leaves `panels.visible` reporting true.
