### PR TITLE
Declare mobile platform support in the plugin manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 Link Graph UI draws a force-directed graph of the links between Joplin notes.
 Nodes are notes, and edges are the links between them.
 
-Joplin 2.13 or later runs the plugin.
+Joplin 2.13 or later runs the plugin on the desktop, and Joplin 3.0.3 or
+later runs it on mobile. An Android emulator running Joplin 3.6.22 verified
+the mobile panel. No iOS test has run.
 
 ![The graph of a whole vault, drawn with Max. distance at 0](docs/screenshots/whole-vault-graph.png)
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,6 +2,8 @@
 	"manifest_version": 1,
 	"id": "io.treymo.LinkGraph",
 	"app_min_version": "2.13",
+	"app_min_version_mobile": "3.0.3",
+	"platforms": ["desktop", "mobile"],
 	"version": "1.6.0",
 	"name": "Link Graph UI",
 	"description": "Visualize the connections between Joplin notes.",


### PR DESCRIPTION
Joplin already installs `io.treymo.LinkGraph` on Android through the allow-list it keeps for plugins predating the `platforms` field. The manifest therefore claims desktop only while its mobile floor resolves to `app_min_version` 2.13, a release predating mobile plugin panels. The two new fields state the support and set the floor at 3.0.3, the value Joplin's own manifest documentation uses.

An Android 15 emulator running Joplin 3.6.22 installed the plugin with no compatibility error, rendered the panel, and opened a note from a touch tap on a node.

Three gaps remain. The `mobile` token covers iOS and no emulator here can exercise it, so the README names Android as the verified platform; pinch zoom needs multi-touch the harness cannot send; and `--joplin-font-family` resolves empty, so the panel uses the system font.

The claim rests on #106, which fits the finished layout inside the panel.
